### PR TITLE
Fix: Normalize API URL construction in Limitless node

### DIFF
--- a/nodes/Limitless/Limitless.node.ts
+++ b/nodes/Limitless/Limitless.node.ts
@@ -188,10 +188,11 @@ export class Limitless implements INodeType {
             if (operation === 'getLifelogs') {
                 const credentials = await this.getCredentials('limitlessApi');
                 const apiUrl = credentials.apiUrl as string;
+                const normalizedApiUrl = apiUrl.replace(/\/$/, "");
 
                 const options = {
                     method: 'GET' as IHttpRequestMethods,
-                    uri: `${apiUrl}/lifelogs`,
+                    uri: `${normalizedApiUrl}/lifelogs`,
                     qs: {
                         date: '',
                         start: '',


### PR DESCRIPTION
Ensures that the API request URL for 'lifelogs' is correctly formed by removing any trailing slash from the user-provided 'apiUrl' before appending '/lifelogs'. This makes the URL construction resilient to variations in how you might enter the 'apiUrl' in the credentials, preventing potential 'Resource not found' errors caused by double slashes or missing slashes.